### PR TITLE
feat: Implement group sharing with feed integration and notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ A social media platform built with Flask, featuring user authentication, profile
     *   Users can create and join groups based on shared interests, hobbies, or any other criteria.
     *   **Group Creation:** Create new groups with a unique name, description, and an optional group image. The creator automatically becomes an admin.
     *   **Joining & Leaving:** Users can easily join public or discoverable groups and leave groups they are part of.
-    *   **Group-Specific Feeds:** Each group has its own dedicated page displaying posts made exclusively within that group.
+    *   **Group-Specific Feeds:** Each group has its own dedicated page displaying posts made exclusively within that group, as well as posts shared to the group by its members.
     *   **Group Membership Visibility:** View a list of members for each group.
     *   **Group Management (for Admins):**
         *   Edit group details (name, description, image).
         *   Remove members from the group.
         *   Delete the group entirely (posts within the group will be disassociated).
-    *   **Notifications:** Members receive notifications for new posts within their groups, and group admins are notified when new users join.
+    *   **Notifications:** Members receive notifications for new posts and shares within their groups, and group admins are notified when new users join.
 *   **Real-time Chat:** (See dedicated section below for more details)
     *   One-on-one conversations.
     *   Real-time messaging with Socket.IO.
@@ -67,11 +67,15 @@ A social media platform built with Flask, featuring user authentication, profile
     *   Polls can be standalone, contextually linked to groups (e.g., created from a group page or when creating a post for a group), or conceptually linked to posts.
     *   Notifications are sent for new polls to relevant users (group members or followers).
 ### Post Sharing
-- Users can now share posts from other users to their own feed or (in future iterations) to groups they are part of.
-- When a post is shared, a new `Share` record is created, linking the sharer, the original post, and optionally a group.
-- The original author of the post receives a notification when their post is shared.
-- Shared posts appear in the main feed, attributed to the user who shared them, and are ordered chronologically based on the share time.
-- Implemented via the `Share` model, a `POST /post/<post_id>/share` route, a "Share" button on posts, and updates to the feed generation logic.
+- Users can share posts from other users to their own personal feed.
+- **Sharing to Groups:** Posts can also be shared directly to groups that the user is a member of.
+    - When a post is shared to a group, it appears in the group's dedicated feed, intermingled with direct posts to the group, sorted chronologically.
+    - The shared post is clearly attributed with "Shared by [User] on [Timestamp]" above the original post content.
+    - Members of the group (excluding the sharer) receive a notification when a new post is shared to the group.
+- When a post is shared (either to a personal feed or a group), a `Share` record is created, linking the sharer, the original post, and (if applicable) the target group.
+- The original author of the post receives a notification when their post is shared (regardless of whether it was to a personal feed or a group, unless they are the one sharing their own post).
+- Shared posts on personal feeds are attributed to the user who shared them and are ordered chronologically based on the share time.
+- This functionality is implemented via the `Share` model, a `POST /post/<post_id>/share` route (which now accepts an optional `group_id`), a "Share" button on posts, and updates to feed generation logic for both personal and group feeds.
 *   CSRF Protection for forms.
 *   Default profile picture for new users.
 *   Unit tests for core features including authentication, profiles, posts, groups, chat, search, stories, and polls.

--- a/app/templates/group.html
+++ b/app/templates/group.html
@@ -57,9 +57,9 @@
                 <p>Join this group to create a post.</p>
             {% endif %}
 
-            {% if posts %}
-                {% for post in posts %}
-                    {% set item_wrapper = {'type': 'post', 'item': post, 'timestamp': post.timestamp, 'sharer': None} %}
+            {% if feed_items %}
+                {% for item_wrapper in feed_items %}
+                    {# item_wrapper is now directly from the feed_items list, already formatted #}
                     {% include '_post.html' %}
                 {% endfor %}
             {% else %}

--- a/tests/test_sharing.py
+++ b/tests/test_sharing.py
@@ -19,7 +19,9 @@ class SharingTestCase(unittest.TestCase):
         self.user1.set_password('password')
         self.user2 = User(username='user2', email='user2@example.com')
         self.user2.set_password('password')
-        db.session.add_all([self.user1, self.user2])
+        self.user3 = User(username='user3', email='user3@example.com') # New user
+        self.user3.set_password('password')
+        db.session.add_all([self.user1, self.user2, self.user3])
         db.session.commit()
 
         # Create a post by user1
@@ -47,22 +49,70 @@ class SharingTestCase(unittest.TestCase):
     def _logout(self):
         return self.client.get('/logout', follow_redirects=True)
 
-    # Helper to create a group and add members
-    def _create_group_with_member(self, creator, member=None):
-        group = Group(name='Test Group', description='A test group', creator=creator)
+    def _add_user_to_group(self, user, group, role='member'):
+        membership = GroupMembership(user_id=user.id, group_id=group.id, role=role)
+        db.session.add(membership)
+        # Removed commit from here to be part of a larger commit in _create_group_with_members
+
+    def _create_group_with_members(self, creator, members_users_roles=None):
+        # Unique group name using timestamp
+        group = Group(name=f'Test Group {datetime.utcnow().timestamp()}', description='A test group', creator=creator)
         db.session.add(group)
-        db.session.flush() # Get group.id
+        db.session.flush()
 
-        # Add creator as admin
-        membership_creator = GroupMembership(user_id=creator.id, group_id=group.id, role='admin')
-        db.session.add(membership_creator)
+        self._add_user_to_group(creator, group, role='admin')
 
-        if member:
-            membership_member = GroupMembership(user_id=member.id, group_id=group.id, role='member')
-            db.session.add(membership_member)
+        if members_users_roles:
+            for user_obj, role in members_users_roles: # Corrected variable name
+                self._add_user_to_group(user_obj, group, role=role)
 
-        db.session.commit()
+        db.session.commit() # Single commit at the end
         return group
+
+    # Optional: Keep the old helper if other tests might use it, or adapt them.
+    # For this task, the new one is preferred.
+    # def _create_group_with_member(self, creator, member=None):
+    #     group = Group(name='Test Group', description='A test group', creator=creator)
+    #     db.session.add(group)
+    #     db.session.flush() # Get group.id
+    #     membership_creator = GroupMembership(user_id=creator.id, group_id=group.id, role='admin')
+    #     db.session.add(membership_creator)
+    #     if member:
+    #         membership_member = GroupMembership(user_id=member.id, group_id=group.id, role='member')
+    #         db.session.add(membership_member)
+    #     db.session.commit()
+    #     return group
+
+    def _check_notification_exists(self, recipient_id, actor_id, type, post_id=None, group_id=None):
+        query = Notification.query.filter_by(
+            recipient_id=recipient_id,
+            actor_id=actor_id,
+            type=type
+        )
+        if post_id:
+            query = query.filter_by(related_post_id=post_id)
+        if group_id:
+            query = query.filter_by(related_group_id=group_id)
+
+        notification = query.first()
+        self.assertIsNotNone(notification,
+            f"Notification not found for recipient {recipient_id}, actor {actor_id}, type {type}, post {post_id}, group {group_id}")
+        return notification
+
+    def _check_notification_does_not_exist(self, recipient_id, actor_id, type, post_id=None, group_id=None):
+        query = Notification.query.filter_by(
+            recipient_id=recipient_id,
+            actor_id=actor_id,
+            type=type
+        )
+        if post_id:
+            query = query.filter_by(related_post_id=post_id)
+        if group_id:
+            query = query.filter_by(related_group_id=group_id)
+
+        notification = query.first()
+        self.assertIsNone(notification,
+            f"Notification unexpectedly found for recipient {recipient_id}, actor {actor_id}, type {type}, post {post_id}, group {group_id}")
 
     def test_share_model_creation(self):
         share = Share(user_id=self.user2.id, post_id=self.post1.id, timestamp=datetime.utcnow())
@@ -100,8 +150,8 @@ class SharingTestCase(unittest.TestCase):
         self.assertIsNone(share) # No share should be created
         self._logout()
 
-    def test_share_post_to_group(self):
-        group = self._create_group_with_member(creator=self.user1, member=self.user2)
+    def test_share_post_to_group(self): # This test can be enhanced or replaced by the new more specific tests
+        group = self._create_group_with_members(creator=self.user1, members_users_roles=[(self.user2, 'member')])
         self._login(self.user2) # user2 will share post1 to the group
 
         response = self.client.post(f'/post/{self.post1.id}/share', data={'group_id': group.id}, follow_redirects=True)
@@ -177,9 +227,133 @@ class SharingTestCase(unittest.TestCase):
         # To be more specific, we could count occurrences or use a more detailed parser,
         # but for now, checking for key phrases is a good start.
         # Ensure the shared item's timestamp is the share_time
-        self.assertIn(f"on {share_time.strftime('%Y-%m-%d %H:%M')}", html_content)
+        self.assertIn(f"on {share_time.strftime('%Y-%m-%d %H:%M')}", html_content) # Check for the share time
 
         self._logout()
+
+    def test_share_post_to_group_feed_and_notifications(self):
+        # 1. Setup: Create group, add user1 (author), user2 (sharer), user3 (member)
+        group = self._create_group_with_members(creator=self.user1, members_users_roles=[
+            (self.user2, 'member'),
+            (self.user3, 'member')
+        ])
+
+        # 2. Action: user2 logs in and shares post1 (by user1) to the group
+        self._login(self.user2)
+        response = self.client.post(f'/post/{self.post1.id}/share', data={'group_id': group.id}, follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Post shared successfully!', response.data)
+
+        # 3. Verify Share Creation
+        share = Share.query.filter_by(user_id=self.user2.id, post_id=self.post1.id, group_id=group.id).first()
+        self.assertIsNotNone(share)
+        self.assertEqual(share.user, self.user2)
+        self.assertEqual(share.original_post, self.post1)
+        self.assertEqual(share.group, group)
+        share_timestamp_str = share.timestamp.strftime('%Y-%m-%d %H:%M') # For checking in HTML
+        self._logout()
+
+        # 4. Verify Group Feed for user3
+        self._login(self.user3)
+        response = self.client.get(f'/group/{group.id}')
+        self.assertEqual(response.status_code, 200)
+        html_content = response.data.decode('utf-8')
+
+        # Check for the "Shared by user2" attribution and the share timestamp
+        # The _post.html template creates a structure like:
+        # <small class="text-muted"> Shared by <a href="...">user2</a> on SHARE_TIMESTAMP UTC </small>
+        # ... then original post details ...
+        self.assertIn(f"Shared by {self.user2.username}", html_content)
+        self.assertIn(f"on {share_timestamp_str}", html_content) # Check for share timestamp
+        self.assertIn(self.post1.body, html_content) # Original post content
+        self.assertIn(self.post1.author.username, html_content) # Original author
+        self._logout()
+
+        # 5. Verify Notifications for Group Members
+        # user1 (post author, group member) should get 'group_share' from user2
+        self._check_notification_exists(recipient_id=self.user1.id, actor_id=self.user2.id,
+                                        type='group_share', post_id=self.post1.id, group_id=group.id)
+
+        # user3 (other group member) should get 'group_share' from user2
+        self._check_notification_exists(recipient_id=self.user3.id, actor_id=self.user2.id,
+                                        type='group_share', post_id=self.post1.id, group_id=group.id)
+
+        # user2 (sharer) should NOT get 'group_share' for their own action
+        self._check_notification_does_not_exist(recipient_id=self.user2.id, actor_id=self.user2.id,
+                                                type='group_share', post_id=self.post1.id, group_id=group.id)
+
+        # 6. Verify Notification for Original Post Author (Standard Share Notification)
+        # user1 (original post author) should also receive the standard 'share' notification from user2
+        self._check_notification_exists(recipient_id=self.user1.id, actor_id=self.user2.id,
+                                        type='share', post_id=self.post1.id)
+        # Ensure this 'share' notification is NOT tied to the group specifically in Notification table
+        std_share_notif = Notification.query.filter_by(recipient_id=self.user1.id, actor_id=self.user2.id, type='share', post_id=self.post1.id).first()
+        self.assertIsNotNone(std_share_notif)
+        self.assertIsNone(std_share_notif.related_group_id)
+
+
+    def test_sharing_own_post_to_group(self):
+        # 1. Setup: Create group, add user1 (author/sharer) and user2 (member)
+        group = self._create_group_with_members(creator=self.user1, members_users_roles=[
+            (self.user2, 'member')
+        ])
+
+        # 2. Action: user1 logs in and shares their own post1 to the group
+        self._login(self.user1)
+        response = self.client.post(f'/post/{self.post1.id}/share', data={'group_id': group.id}, follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Post shared successfully!', response.data)
+
+        # 3. Verify Share Creation
+        share = Share.query.filter_by(user_id=self.user1.id, post_id=self.post1.id, group_id=group.id).first()
+        self.assertIsNotNone(share)
+        share_timestamp_str = share.timestamp.strftime('%Y-%m-%d %H:%M')
+        self._logout()
+
+        # 4. Verify Group Feed for user2
+        self._login(self.user2)
+        response = self.client.get(f'/group/{group.id}')
+        self.assertEqual(response.status_code, 200)
+        html_content = response.data.decode('utf-8')
+        self.assertIn(f"Shared by {self.user1.username}", html_content) # Shared by user1
+        self.assertIn(f"on {share_timestamp_str}", html_content)
+        self.assertIn(self.post1.body, html_content)
+        self._logout()
+
+        # 5. Verify Notifications
+        # user2 (other group member) should get 'group_share' from user1
+        self._check_notification_exists(recipient_id=self.user2.id, actor_id=self.user1.id,
+                                        type='group_share', post_id=self.post1.id, group_id=group.id)
+
+        # user1 (sharer and author) should NOT get 'group_share'
+        self._check_notification_does_not_exist(recipient_id=self.user1.id, actor_id=self.user1.id,
+                                                type='group_share', post_id=self.post1.id, group_id=group.id)
+
+        # user1 (sharer and author) should NOT get standard 'share' notification (as they shared their own post)
+        # The route logic for standard 'share' is `if post_to_share.author != current_user:`
+        self._check_notification_does_not_exist(recipient_id=self.user1.id, actor_id=self.user1.id,
+                                                type='share', post_id=self.post1.id)
+
+    def test_prevent_duplicate_share_to_same_group(self):
+        # 1. Setup: Create group, add user2 as member
+        group = self._create_group_with_members(creator=self.user1, members_users_roles=[(self.user2, 'member')])
+
+        # 2. Action: user2 logs in and shares post1 to the group
+        self._login(self.user2)
+        response_first_share = self.client.post(f'/post/{self.post1.id}/share', data={'group_id': group.id}, follow_redirects=True)
+        self.assertEqual(response_first_share.status_code, 200)
+        self.assertIn(b'Post shared successfully!', response_first_share.data)
+
+        # 3. Attempt to share again to the same group
+        response_second_share = self.client.post(f'/post/{self.post1.id}/share', data={'group_id': group.id}, follow_redirects=True)
+        self.assertEqual(response_second_share.status_code, 200)
+        self.assertIn(b'You have already shared this post to this destination.', response_second_share.data)
+        self._logout()
+
+        # 4. Verify No New Share
+        shares = Share.query.filter_by(user_id=self.user2.id, post_id=self.post1.id, group_id=group.id).all()
+        self.assertEqual(len(shares), 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit introduces the ability for users to share posts to groups.

Key changes:

- Group feeds (`/group/<id>`) now display both direct posts to the group and posts shared to the group by its members. Shared posts are clearly marked with "Shared by [User] on [Timestamp]" and show the original post content.
- When a post is shared to a group, all group members (except the user who shared the post) receive a notification of type 'group_share'.
- The original author of a shared post also continues to receive a standard 'share' notification if they are not the one sharing it.
- I've updated the tests to include comprehensive checks for group sharing functionality, covering feed display, notification generation for various scenarios (sharing by member, sharing own post to group), and prevention of duplicate shares to the same group.
- The `README.md` file has been updated to reflect these new capabilities in the "Post Sharing" and "User Groups/Communities" sections.

The `view_group` route in `app/routes.py` was modified to fetch and combine direct and shared posts. The `group.html` template was updated to render this combined feed. The `share_post` route now handles the creation of 'group_share' notifications and emits corresponding Socket.IO events.